### PR TITLE
fixed(): LSP Improvements + Config

### DIFF
--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -1,11 +1,35 @@
 local cmp = require'cmp'
 local lspconfig = require'lspconfig'
 
+-- Enhanced capabilities for better LSP support
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+-- Add this function to check LSP attachment
+local function on_attach(client, bufnr)
+  print("LSP attached: " .. client.name .. " to buffer " .. bufnr)
+  
+  -- Enable completion triggered by <c-x><c-o>
+  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  -- Buffer local mappings
+  local bufopts = { noremap=true, silent=true, buffer=bufnr }
+  vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
+  vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
+  vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+  vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
+  vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
+  vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, bufopts)
+  vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, bufopts)
+  vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
+end
+
+-- Your existing cmp setup...
 function TabCompletion (fallback)
   if cmp.visible() then
     cmp.select_next_item()
   else
-    fallback() -- If you use vim-endwise, this fallback will behave the same as vim-endwise.
+    fallback()
   end
 end
 
@@ -13,7 +37,7 @@ function ReverseTabCompletion (fallback)
   if cmp.visible() then
     cmp.select_prev_item()
   else
-    fallback() -- If you use vim-endwise, this fallback will behave the same as vim-endwise.
+    fallback()
   end
 end
 
@@ -21,18 +45,17 @@ function ReturnCompletion (fallback)
   if cmp.visible() then
     cmp.confirm({ behavior = cmp.ConfirmBehavior.Replace, select = true })
   else
-    fallback() -- If you use vim-endwise, this fallback will behave the same as vim-endwise.
+    fallback()
   end
 end
 
 cmp.setup({
   snippet = {
     expand = function(args)
-      vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
+      vim.fn["vsnip#anonymous"](args.body)
     end,
   },
   window = {
-    -- completion = cmp.config.window.bordered(),
     documentation = cmp.config.window.bordered(),
   },
   completion = {
@@ -48,52 +71,16 @@ cmp.setup({
   }),
   sources = cmp.config.sources({
     { name = 'nvim_lsp' },
-    -- { name = 'vsnip' }, -- For vsnip users.
-    -- { name = 'luasnip' }, -- For luasnip users.
-    -- { name = 'ultisnips' }, -- For ultisnips users.
-    -- { name = 'snippy' }, -- For snippy users.
   }, {
     { name = 'buffer' },
   })
 })
 
--- Set configuration for specific filetype.
-cmp.setup.filetype('gitcommit', {
-  sources = cmp.config.sources({
-    { name = 'git' }, -- You can specify the `git` source if [you were installed it](https://github.com/petertriho/cmp-git).
-  }, {
-    { name = 'buffer' },
-  })
-})
-
--- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
-cmp.setup.cmdline({ '/', '?' }, {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = {
-    { name = 'buffer' }
-  }
-})
-
--- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
-cmp.setup.cmdline(':', {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = cmp.config.sources({
-    { name = 'path' }
-  }, {
-    { name = 'cmdline' }
-  })
-})
-
--- Set up lspconfig.
-local capabilities = require('cmp_nvim_lsp').default_capabilities()
-lspconfig.tsserver.setup{
-  capabilities = capabilities,
-  filetypes = { "typescript", "typescriptreact", "typescript.tsx" },
-  cmd = { "typescript-language-server", "--stdio" }
-}
+-- Enhanced gopls setup
 lspconfig.gopls.setup{
   capabilities = capabilities,
-  cmd = { "gopls" },
+  on_attach = on_attach,
+  cmd = { "gopls", "serve" },
   filetypes = { "go", "gomod", "gowork", "gotmpl" },
   root_dir = lspconfig.util.root_pattern("go.work", "go.mod", ".git"),
   settings = {
@@ -102,10 +89,62 @@ lspconfig.gopls.setup{
       usePlaceholders = true,
       analyses = {
         unusedparams = true,
+        shadow = true,
       },
       staticcheck = true,
       gofumpt = true,
+      codelenses = {
+        gc_details = false,
+        generate = true,
+        regenerate_cgo = true,
+        run_govulncheck = true,
+        test = true,
+        tidy = true,
+        upgrade_dependency = true,
+        vendor = true,
+      },
+      hints = {
+        assignVariableTypes = true,
+        compositeLiteralFields = true,
+        compositeLiteralTypes = true,
+        constantValues = true,
+        functionTypeParameters = true,
+        parameterNames = true,
+        rangeVariableTypes = true,
+      },
     },
   },
 }
 
+-- TypeScript setup (updated to use ts_ls instead of deprecated tsserver)
+lspconfig.ts_ls.setup{
+  capabilities = capabilities,
+  on_attach = on_attach,
+  filetypes = { "typescript", "typescriptreact", "javascript", "javascriptreact" },
+  cmd = { "typescript-language-server", "--stdio" },
+  root_dir = lspconfig.util.root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git"),
+  settings = {
+    typescript = {
+      inlayHints = {
+        includeInlayParameterNameHints = "all",
+        includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+        includeInlayFunctionParameterTypeHints = true,
+        includeInlayVariableTypeHints = true,
+        includeInlayPropertyDeclarationTypeHints = true,
+        includeInlayFunctionLikeReturnTypeHints = true,
+        includeInlayEnumMemberValueHints = true,
+      },
+    },
+    javascript = {
+      inlayHints = {
+        includeInlayParameterNameHints = "all",
+        includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+        includeInlayFunctionParameterTypeHints = true,
+        includeInlayVariableTypeHints = true,
+        includeInlayPropertyDeclarationTypeHints = true,
+        includeInlayFunctionLikeReturnTypeHints = true,
+        includeInlayEnumMemberValueHints = true,
+      },
+    },
+  },
+}

--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -42,16 +42,29 @@ map("n", "<Leader>f", ":FindCurrentWord<CR>")
 map("n", "<Leader>s", ":Files<CR>")
 map("n", "<Leader>b", ":Buffers<CR>")
 
--- LSP Bindings
-map('n', '<Leader>d', ':lua vim.lsp.buf.definition()<CR>')
-map('n', 'gD', ':lua vim.lsp.buf.declaration()<CR>')
-map('n', 'gi', ':lua vim.lsp.buf.implementation()<CR>')
-map('n', 'gw', ':lua vim.lsp.buf.document_symbol()<CR>')
-map('n', 'gW', ':lua vim.lsp.buf.workspace_symbol()<CR>')
-map('n', 'gr', ':lua vim.lsp.buf.references()<CR>')
-map('n', 'gt', ':lua vim.lsp.buf.type_definition()<CR>')
-map('n', 'K', ':lua vim.lsp.buf.hover()<CR>')
-map('n', '<c-k>', ':lua vim.lsp.buf.signature_help()<CR>')
-map('n', '<leader>af', ':lua vim.lsp.buf.code_action()<CR>')
-map('n', '<leader>rn', ':lua vim.lsp.buf.rename()<CR>')
-map('n', '<leader>e', ':lua vim.diagnostic.open_float()<CR>')
+-- LSP Bindings - These will be set up properly in the on_attach function
+-- But we'll also set global fallbacks in case on_attach doesn't work
+map('n', '<Leader>d', '<cmd>lua vim.lsp.buf.definition()<CR>')
+map('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>')
+map('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<CR>')
+map('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>')
+map('n', 'gw', '<cmd>lua vim.lsp.buf.document_symbol()<CR>')
+map('n', 'gW', '<cmd>lua vim.lsp.buf.workspace_symbol()<CR>')
+map('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>')
+map('n', 'gt', '<cmd>lua vim.lsp.buf.type_definition()<CR>')
+map('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>')
+map('n', '<c-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>')
+map('n', '<leader>af', '<cmd>lua vim.lsp.buf.code_action()<CR>')
+map('n', '<leader>rn', '<cmd>lua vim.lsp.buf.rename()<CR>')
+map('n', '<leader>e', '<cmd>lua vim.diagnostic.open_float()<CR>')
+
+-- Diagnostic navigation
+map('n', '[d', '<cmd>lua vim.diagnostic.goto_prev()<CR>')
+map('n', ']d', '<cmd>lua vim.diagnostic.goto_next()<CR>')
+map('n', '<leader>q', '<cmd>lua vim.diagnostic.setloclist()<CR>')
+
+-- CodeCompanion mappings for better Claude integration
+map("n", "<leader>cc", ":CodeCompanion<CR>", { desc = "Open Claude chat" })
+map("v", "<leader>ca", ":CodeCompanionActions<CR>", { desc = "Claude actions on selection" })
+map("n", "<leader>ct", ":CodeCompanionToggle<CR>", { desc = "Toggle Claude chat" })
+map("n", "<leader>cq", ":CodeCompanionCmd ", { desc = "Quick Claude command" })

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -88,14 +88,18 @@ vim.cmd([[
   set runtimepath+=$GOROOT/misc/vim
   
   " Disable vim-go LSP features to avoid conflicts with gopls
-  let g:go_def_mapping_enabled = 1
+  let g:go_def_mapping_enabled = 0
   let g:go_code_completion_enabled = 0
-  let g:go_gopls_enabled = 1
+  let g:go_gopls_enabled = 0
   
   " Use LSP for these features instead of vim-go
   let g:go_def_mode = 'gopls'
   let g:go_info_mode = 'gopls'
   let g:go_referrers_mode = 'gopls'
+
+  " Disable vim-go's default mappings that conflict with LSP
+  let g:go_doc_keywordprg_enabled = 0
+  let g:go_textobj_enabled = 0
   
   " Keep vim-go features that complement LSP
   let g:go_fmt_autosave = 1
@@ -123,8 +127,7 @@ vim.cmd([[
 local ts_status, treesitter = pcall(require, "nvim-treesitter.configs")
 if ts_status then
   treesitter.setup({
-    ensure_installed = { "lua", "markdown", "markdown_inline", "yaml" },
+    ensure_installed = { "lua", "markdown", "markdown_inline", "yaml", "go" },
     highlight = { enable = true },
   })
 end
-

--- a/zsh-custom/aliases_general.zsh
+++ b/zsh-custom/aliases_general.zsh
@@ -6,3 +6,4 @@ alias v='nvim'
 
 alias gastro='cd /Users/adam.trimble/Documents/gastro-web; nvim'
 alias kitchen='cd /Users/adam.trimble/Documents/kitchen; nvim'
+alias dotfiles='cd /Users/adam.trimble/Documents/dotfiles; nvim'

--- a/zsh-custom/aliases_goat.zsh
+++ b/zsh-custom/aliases_goat.zsh
@@ -4,6 +4,7 @@ alias protos='cd /Users/adam.trimble/Documents/protos; nvim'
 alias sell='cd /Users/adam.trimble/Documents/sell-alias-org; nvim'
 alias sneakers='cd /Users/adam.trimble/Documents/sneakers; nvim'
 alias stores='cd /Users/adam.trimble/Documents/go-services/sell/shopify-stores; nvim'
+alias analytics='cd /Users/adam.trimble/Documents/go-services/sell/analytics; nvim'
 alias sync='cd /Users/adam.trimble/Documents/go-services/sell/shopify-sync; nvim'
 alias webhooks='cd /Users/adam.trimble/Documents/go-services/sell/shopify-webhooks; nvim'
 


### PR DESCRIPTION
This pull request introduces several improvements and updates to the Neovim configuration, including enhanced LSP support, updated plugin configurations, and additional aliases for productivity. Below is a breakdown of the most significant changes:

### LSP Enhancements
* Added an `on_attach` function in `nvim/lua/lsp.lua` to set up buffer-specific key mappings and enable omnifunc for LSP-attached buffers. This improves usability and ensures consistent LSP behavior.
* Enhanced the `gopls` configuration with additional settings, such as enabling codelenses and hints for better Go development experience.
* Updated TypeScript LSP configuration to use `ts_ls` instead of the deprecated `tsserver` and added inlay hints for improved developer experience.

### Key Mapping Updates
* Reorganized LSP key bindings in `nvim/lua/mappings.lua` to use `<cmd>` syntax for better compatibility, added diagnostic navigation mappings, and introduced new mappings for "CodeCompanion" integration with Claude.

### Plugin Configuration Updates
* Disabled conflicting vim-go LSP features to avoid redundancy with `gopls`, while retaining complementary features like auto-formatting and imports.
* Updated Treesitter configuration to include Go support, enhancing syntax highlighting for Go files.

### Productivity Aliases
* Added new aliases in `zsh-custom/aliases_general.zsh` and `zsh-custom/aliases_goat.zsh` for quick navigation to frequently used directories, such as `dotfiles` and `analytics`. [[1]](diffhunk://#diff-10678919f7ac72557eb861e42a267a10cded766ad4ddcc26d8c853b18b49061bR9) [[2]](diffhunk://#diff-9a8c501afd031348ed4b83e13b6c66f8a6bb09c9dd878e1c3524a7330007ef72R7)